### PR TITLE
Improve relic respawn

### DIFF
--- a/Automata/Assets/Level1.unity
+++ b/Automata/Assets/Level1.unity
@@ -140,7 +140,7 @@ Prefab:
       propertyPath: m_LocalScale.z
       value: 1.9633933
       objectReference: {fileID: 0}
-    - target: {fileID: 21239882, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+    - target: {fileID: 0}
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
@@ -385,7 +385,7 @@ Prefab:
       propertyPath: m_LocalScale.z
       value: 1.9633933
       objectReference: {fileID: 0}
-    - target: {fileID: 21239882, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+    - target: {fileID: 0}
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
@@ -465,6 +465,10 @@ Prefab:
       propertyPath: m_LocalPosition.x
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 168218, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_TagString
+      value: Respawn
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
   m_IsPrefabParent: 0
@@ -538,6 +542,14 @@ Prefab:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 466270, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 466270, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.x
       value: 1
       objectReference: {fileID: 0}
@@ -1598,7 +1610,7 @@ Prefab:
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 21239882, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+    - target: {fileID: 0}
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
@@ -1974,7 +1986,7 @@ Prefab:
       propertyPath: m_LocalScale.z
       value: 1.9633933
       objectReference: {fileID: 0}
-    - target: {fileID: 21239882, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+    - target: {fileID: 0}
       propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}

--- a/Automata/Assets/Level1.unity
+++ b/Automata/Assets/Level1.unity
@@ -94,11 +94,11 @@ Prefab:
     m_Modifications:
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.x
-      value: 801.3
+      value: 806
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 305
+      value: 304
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.z
@@ -114,11 +114,11 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalRotation.z
-      value: -0.7071068
+      value: 0.7071066
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalRotation.w
-      value: 0.7071067
+      value: -0.70710695
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_RootOrder
@@ -126,7 +126,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 182906, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Name
-      value: Fountain (2)
+      value: Level 3 Fountain
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.x
@@ -146,7 +146,19 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 21261844, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: -0.00000016292068
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
@@ -327,11 +339,11 @@ Prefab:
     m_Modifications:
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.x
-      value: 265.7
+      value: 264
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.y
-      value: -202
+      value: -198
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.z
@@ -359,7 +371,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 182906, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Name
-      value: Fountain (4)
+      value: Level 5 Fountain
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.y
@@ -379,7 +391,11 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 21261844, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
@@ -399,11 +415,11 @@ Prefab:
     m_Modifications:
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.x
-      value: 750
+      value: 753
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.y
-      value: -751.3
+      value: -750
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.z
@@ -431,7 +447,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 182906, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Name
-      value: Fountain (8)
+      value: Level 9 Fountain
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.x
@@ -444,6 +460,10 @@ Prefab:
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.z
       value: 1.9633933
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
@@ -467,7 +487,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 454
+      value: 456
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.z
@@ -483,15 +503,43 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: 0.7071066
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: -0.70710695
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_RootOrder
       value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 21261844, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: -0.00000016292068
+      objectReference: {fileID: 0}
+    - target: {fileID: 182906, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_Name
+      value: Level 1 Fountain
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
@@ -575,11 +623,11 @@ Prefab:
     m_Modifications:
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.x
-      value: -1510.6
+      value: -1512
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.y
-      value: -596
+      value: -590
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.z
@@ -607,7 +655,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 182906, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Name
-      value: Fountain (6)
+      value: Level 7 Fountain
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.y
@@ -620,6 +668,10 @@ Prefab:
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.z
       value: 1.9633933
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
@@ -893,11 +945,11 @@ Prefab:
     m_Modifications:
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.x
-      value: -804.3
+      value: -813
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.y
-      value: -305
+      value: -290
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.z
@@ -925,7 +977,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 182906, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Name
-      value: Fountain (5)
+      value: Level 6 Fountain
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.y
@@ -938,6 +990,10 @@ Prefab:
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.z
       value: 1.9633933
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
@@ -1492,11 +1548,11 @@ Prefab:
     m_Modifications:
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.x
-      value: 1586
+      value: 1590
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 216.8
+      value: 210
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.z
@@ -1524,7 +1580,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 182906, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Name
-      value: Fountain (3)
+      value: Level 4 Fountain
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.y
@@ -1540,11 +1596,15 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 21261844, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 21239882, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Enabled
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
@@ -1564,11 +1624,11 @@ Prefab:
     m_Modifications:
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.x
-      value: -437
+      value: -427
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.y
-      value: -446
+      value: -443
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.z
@@ -1596,7 +1656,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 182906, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Name
-      value: Fountain (7)
+      value: Level 8 Fountain
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.x
@@ -1609,6 +1669,10 @@ Prefab:
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.z
       value: 1.9633933
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
@@ -1868,7 +1932,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.y
-      value: 662
+      value: 665
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalPosition.z
@@ -1884,11 +1948,11 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalRotation.z
-      value: -0.7071068
+      value: 0.7071066
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalRotation.w
-      value: 0.7071067
+      value: -0.70710695
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_RootOrder
@@ -1896,7 +1960,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 182906, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Name
-      value: Fountain (1)
+      value: Level 2 Fountain
       objectReference: {fileID: 0}
     - target: {fileID: 433130, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalScale.x
@@ -1916,7 +1980,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 21261844, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalRotation.z
@@ -1925,6 +1989,18 @@ Prefab:
     - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
       propertyPath: m_LocalRotation.w
       value: -0.00000016292068
+      objectReference: {fileID: 0}
+    - target: {fileID: 466270, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 466270, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: 495368, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a7da478584e9c488aa3cc9c200e95392, type: 2}

--- a/Automata/Assets/Objects/Prefabs/Fountain.prefab
+++ b/Automata/Assets/Objects/Prefabs/Fountain.prefab
@@ -81,7 +81,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 165034}
   m_LocalRotation: {x: 0, y: 0, z: 1, w: -0.00000016292068}
-  m_LocalPosition: {x: 0, y: 0, z: -2}
+  m_LocalPosition: {x: 1, y: 0, z: -2}
   m_LocalScale: {x: 200, y: 200, z: 1}
   m_Children: []
   m_Father: {fileID: 433130}
@@ -98,7 +98,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   resourcePrefab: {fileID: 104054, guid: 95850e4cb50eb444b8c54981dd76a2ee, type: 2}
-  host: {fileID: 0}
 --- !u!212 &21239882
 SpriteRenderer:
   m_ObjectHideFlags: 1
@@ -135,7 +134,7 @@ SpriteRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 165034}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
   m_Materials:
@@ -168,7 +167,7 @@ Prefab:
     m_Modifications:
     - target: {fileID: 0}
       propertyPath: m_Enabled
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 0}
       propertyPath: m_LocalRotation.z
@@ -177,6 +176,18 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: m_LocalRotation.w
       value: -0.00000016292068
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPosition.z
+      value: -2
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPosition.x
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}

--- a/Automata/Assets/Objects/Prefabs/Fountain.prefab
+++ b/Automata/Assets/Objects/Prefabs/Fountain.prefab
@@ -24,10 +24,9 @@ GameObject:
   serializedVersion: 4
   m_Component:
   - 4: {fileID: 466270}
-  - 212: {fileID: 21239882}
   m_Layer: 0
-  m_Name: New Sprite
-  m_TagString: Untagged
+  m_Name: Relic Target
+  m_TagString: Respawn
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -69,7 +68,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 168218}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -1}
+  m_LocalPosition: {x: 1, y: 15, z: -1}
   m_LocalScale: {x: 200, y: 200, z: 1}
   m_Children: []
   m_Father: {fileID: 433130}
@@ -98,36 +97,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   resourcePrefab: {fileID: 104054, guid: 95850e4cb50eb444b8c54981dd76a2ee, type: 2}
---- !u!212 &21239882
-SpriteRenderer:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 168218}
-  m_Enabled: 0
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000e000000000000000, type: 0}
-  m_SubsetIndices: 
-  m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 0
-  m_ReflectionProbeUsage: 0
-  m_ProbeAnchor: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
+  respawnPointPrefab: {fileID: 168218}
 --- !u!212 &21261844
 SpriteRenderer:
   m_ObjectHideFlags: 1
@@ -189,6 +159,22 @@ Prefab:
       propertyPath: m_LocalPosition.x
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_Name
+      value: Relic Target
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_LocalPosition.y
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: m_TagString
+      value: Respawn
+      objectReference: {fileID: 0}
+    - target: {fileID: 0}
+      propertyPath: respawnPointPrefab
+      value: 
+      objectReference: {fileID: 168218}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 182906}

--- a/Automata/Assets/Scripts/Ressources/Fountain.cs
+++ b/Automata/Assets/Scripts/Ressources/Fountain.cs
@@ -3,6 +3,7 @@ using System.Collections;
 
 public class Fountain : MonoBehaviour {
 	public GameObject resourcePrefab;
+    public GameObject respawnPointPrefab;
 
 	public void generateResource() {
 		GameObject prefab = (GameObject)Instantiate(resourcePrefab, transform.position, Quaternion.LookRotation(transform.forward, transform.right));

--- a/Automata/Assets/Scripts/Ressources/Resource.cs
+++ b/Automata/Assets/Scripts/Ressources/Resource.cs
@@ -7,6 +7,8 @@ public class Resource : MonoBehaviour{
 	public int level;
 
 	private bool m_collisionEnabled;
+    private Vector3 m_StartPos;
+    private Vector3 m_EndPos;
 
 	// Use this for initialization
 	void Start () {
@@ -20,6 +22,9 @@ public class Resource : MonoBehaviour{
 		transform.SetParent(fount.gameObject.transform);
 		transform.localPosition = new Vector3(1,0,0);
         transform.localEulerAngles = new Vector3(1,0,0);
+        transform.SetParent(null);
+        m_StartPos = transform.position;
+        m_EndPos = fount.respawnPointPrefab.transform.position;
 
 		StartCoroutine ("Animate");
 	}
@@ -49,8 +54,10 @@ public class Resource : MonoBehaviour{
 	}
 
 	IEnumerator Animate() {
-		for (int i = 10; i > 0; i--) {
-			transform.position += transform.up*1.5f;
+        const int kNumSteps = 10;
+
+        for (int i = 1; i <= kNumSteps; i++) {
+            transform.position = Vector3.Lerp(m_StartPos, m_EndPos, i / (float)kNumSteps);
 			yield return new WaitForSeconds(0.01f);
 		}
 		this.canCollide = true;
@@ -71,7 +78,6 @@ public class Resource : MonoBehaviour{
 			if (other.gameObject.GetComponent<Sink>() == wrld.lData[World.currentLevel].Target) {
 				Debug.Log ("Level Finished!");
 				wrld.nextLevel();
-				//Pos = new Vector2(-2f,-2f);
 			}
 			break;
 		}

--- a/Automata/Assets/Scripts/Ressources/Resource.cs
+++ b/Automata/Assets/Scripts/Ressources/Resource.cs
@@ -19,7 +19,7 @@ public class Resource : MonoBehaviour{
 		parent = null;
 		transform.SetParent(fount.gameObject.transform);
 		transform.localPosition = new Vector3(1,0,0);
-		transform.localEulerAngles = new Vector3(1,0,0);
+        transform.localEulerAngles = new Vector3(1,0,0);
 
 		StartCoroutine ("Animate");
 	}
@@ -49,7 +49,7 @@ public class Resource : MonoBehaviour{
 	}
 
 	IEnumerator Animate() {
-		for (int i = 25; i > 0; i--) {
+		for (int i = 10; i > 0; i--) {
 			transform.position += transform.up*1.5f;
 			yield return new WaitForSeconds(0.01f);
 		}


### PR DESCRIPTION
Relics were respawning to a slightly different position after the start of a level. The position is now consistent across all respawns.

Additionally, the spawn position is settable in the Unity editor.
