### PR TITLE
Relic respawn

### DIFF
--- a/Automata/Assets/Scripts/Adherent.cs
+++ b/Automata/Assets/Scripts/Adherent.cs
@@ -33,8 +33,8 @@ public class Adherent : MonoBehaviour {
         m_pathTparam %= pathObject.path.Length;
         Vector2 point = pathObject.path.GetPointAt(m_pathTparam);
         float angle = pathObject.path.GetAngleAt(m_pathTparam);
-        float inter = pathObject.path.GetIntersectionBetween(oldX, m_pathTparam);
-        if (inter != -1) {
+        IntersectionData inter = pathObject.path.GetIntersectionBetween(oldX, m_pathTparam);
+        if (!inter.isEmpty()) {
             Resource levelRes = ResourceManager.levelResource(level);
 
             if (isCarrying && levelRes.canCollide) {

--- a/Automata/Assets/Scripts/Adherent.cs
+++ b/Automata/Assets/Scripts/Adherent.cs
@@ -36,12 +36,9 @@ public class Adherent : MonoBehaviour {
         float inter = pathObject.path.GetIntersectionBetween(oldX, m_pathTparam);
         if (inter != -1) {
             Resource levelRes = ResourceManager.levelResource(level);
-            Vector2 interPoint = point + new Vector2(host.transform.position.x, host.transform.position.y);
-            float dist = (levelRes.Pos - interPoint).magnitude;
 
             if (isCarrying && levelRes.canCollide) {
                 this.detach(levelRes, true);
-                levelRes.Pos = interPoint;
             }
         }
         follower.place(point + new Vector2(host.transform.position.x, host.transform.position.y), angle);
@@ -64,7 +61,6 @@ public class Adherent : MonoBehaviour {
     public Adherent attach(Resource res) {
         follower.swapSprite();
         isCarrying = true;
-        res.Pos = new Vector2(-2f, -2f);
 
         res.gameObject.transform.SetParent(follower.host.transform);
         res.gameObject.transform.localPosition = new Vector3(0, 0, 0);

--- a/Automata/Assets/Scripts/Adherent.cs
+++ b/Automata/Assets/Scripts/Adherent.cs
@@ -34,7 +34,7 @@ public class Adherent : MonoBehaviour {
         Vector2 point = pathObject.path.GetPointAt(m_pathTparam);
         float angle = pathObject.path.GetAngleAt(m_pathTparam);
         IntersectionData inter = pathObject.path.GetIntersectionBetween(oldX, m_pathTparam);
-        if (!inter.isEmpty()) {
+        if (inter.hasData()) {
             Resource levelRes = ResourceManager.levelResource(level);
 
             if (isCarrying && levelRes.canCollide) {

--- a/Automata/Assets/Scripts/Adherent.cs
+++ b/Automata/Assets/Scripts/Adherent.cs
@@ -39,6 +39,7 @@ public class Adherent : MonoBehaviour {
 
             if (isCarrying && levelRes.canCollide) {
                 this.detach(levelRes, true);
+                levelRes.addIntersectionAdherents(inter.adherents);
             }
         }
         follower.place(point + new Vector2(host.transform.position.x, host.transform.position.y), angle);
@@ -62,6 +63,7 @@ public class Adherent : MonoBehaviour {
     public Adherent attach(Resource res) {
         follower.swapSprite();
         isCarrying = true;
+        res.clearIntersectionAdherents();
 
         res.gameObject.transform.SetParent(follower.host.transform);
         res.gameObject.transform.localPosition = new Vector3(0, 0, 0);

--- a/Automata/Assets/Scripts/Adherent.cs
+++ b/Automata/Assets/Scripts/Adherent.cs
@@ -44,8 +44,9 @@ public class Adherent : MonoBehaviour {
         follower.place(point + new Vector2(host.transform.position.x, host.transform.position.y), angle);
     }
 
-    public void setpath(Path p) {
+    public void setPath(Path p) {
         pathObject.setShape(p);
+        p.parentAdherent = this;
     }
 
     public void setPos(float t) {

--- a/Automata/Assets/Scripts/Path.cs
+++ b/Automata/Assets/Scripts/Path.cs
@@ -3,12 +3,33 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-public class Path {
 
-    private struct IntersectionData {
-        public float pos;
-        public List<WeakReference> adherents;
+public class IntersectionData {
+    public float pos;
+    public List<WeakReference> adherents;
+
+    private IntersectionData() {
+        pos = -1f;
+        adherents = new List<WeakReference>();
     }
+
+    public IntersectionData(float position, Adherent ad1, Adherent ad2) {
+        pos = position;
+        adherents = new List<WeakReference>();
+        adherents.Add(new WeakReference(ad1));
+        adherents.Add(new WeakReference(ad2));
+    }
+
+    static public IntersectionData createEmpty() {
+        return new IntersectionData();
+    }
+
+    public bool isEmpty() {
+        return pos == -1 && adherents.Count == 0;
+    }
+}
+
+public class Path {
 
     private struct SegmentPos {
         public int index;
@@ -148,11 +169,7 @@ public class Path {
 
                 float r = lineLineIntersectionRatio(p1p1, p1p2, p2p1, p2p2);
                 if (r >= 0 && r <= 1) {
-                    IntersectionData data;
-                    data.pos = pos + r * segmentLengths[i];
-                    data.adherents = new List<WeakReference>();
-                    data.adherents.Add(new WeakReference(this.parentAdherent));
-                    data.adherents.Add(new WeakReference(p.parentAdherent));
+                    IntersectionData data = new IntersectionData(pos + r * segmentLengths[i], this.parentAdherent, p.parentAdherent);
                     intersectionPositions.Add(data);
                 }
             }
@@ -191,14 +208,14 @@ public class Path {
         return false;
     }
 
-    public float GetIntersectionBetween(float pos1, float pos2) {
+    public IntersectionData GetIntersectionBetween(float pos1, float pos2) {
         for (int i = 0; i < intersectionPositions.Count; i++) {
             float ipos = intersectionPositions[i].pos;
             if (ipos >= pos1 && (ipos < pos2 || pos2 < pos1)) {
-                return ipos;
+                return intersectionPositions[i];
             }
         }
-        return -1;
+        return IntersectionData.createEmpty();
     }
 
     public float DistanceToPath(Vector2 point) {

--- a/Automata/Assets/Scripts/Path.cs
+++ b/Automata/Assets/Scripts/Path.cs
@@ -24,8 +24,8 @@ public class IntersectionData {
         return new IntersectionData();
     }
 
-    public bool isEmpty() {
-        return pos == -1 && adherents.Count == 0;
+    public bool hasData() {
+        return pos != -1 && adherents.Count > 0;
     }
 }
 

--- a/Automata/Assets/Scripts/Path.cs
+++ b/Automata/Assets/Scripts/Path.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -8,9 +9,11 @@ public class Path {
     private float length;
 
     private List<float> intersectionPositions;
+    private WeakReference m_Adherent;
 
     public Path(Vector2[] points) {
         this.points = points;
+        m_Adherent = null;
         segmentLengths = new float[points.Length];
         length = 0;
         for (int i = 0; i < points.Length; i++) {
@@ -42,6 +45,16 @@ public class Path {
         }
 
         return new Path(points);
+    }
+
+    public Adherent parentAdherent {
+        get {
+            return (Adherent)m_Adherent.Target;
+        }
+
+        set {
+            m_Adherent = new WeakReference(value);
+        }
     }
 
     public Vector2[] Points {

--- a/Automata/Assets/Scripts/Path.cs
+++ b/Automata/Assets/Scripts/Path.cs
@@ -129,7 +129,6 @@ public class Path {
 
                 float r = lineLineIntersectionRatio(p1p1, p1p2, p2p1, p2p2);
                 if (r >= 0 && r <= 1) {
-                    Vector2 point = (p1p2 - p1p1) * r + p1p1;
                     intersectionPositions.Add(pos + r * segmentLengths[i]);
                 }
             }

--- a/Automata/Assets/Scripts/Ressources/Resource.cs
+++ b/Automata/Assets/Scripts/Ressources/Resource.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 
 public class Resource : MonoBehaviour {
-    public Vector2 Pos;
     public Adherent parent;
     public int level;
 

--- a/Automata/Assets/Scripts/Ressources/Resource.cs
+++ b/Automata/Assets/Scripts/Ressources/Resource.cs
@@ -1,5 +1,7 @@
 ﻿using UnityEngine;
+using System;
 using System.Collections;
+using System.Collections.Generic;
 
 public class Resource : MonoBehaviour {
     public Adherent parent;
@@ -8,10 +10,12 @@ public class Resource : MonoBehaviour {
     private bool m_collisionEnabled;
     private Vector3 m_StartPos;
     private Vector3 m_EndPos;
+    List<WeakReference> m_intersectionAdherents;
 
     // Use this for initialization
     void Start() {
         parent = null;
+        m_intersectionAdherents = null;
         this.canCollide = false;
         StartCoroutine ("Animate");
     }
@@ -26,6 +30,32 @@ public class Resource : MonoBehaviour {
         m_EndPos = fount.respawnPointPrefab.transform.position;
 
         StartCoroutine ("Animate");
+    }
+
+    public void addIntersectionAdherents(List<WeakReference> adherents) {
+        m_intersectionAdherents = adherents;
+    }
+
+    public void clearIntersectionAdherents() {
+        m_intersectionAdherents = null;
+    }
+
+    public void notifyOfAdherentRemove(Adherent adherent, Fountain fount) {
+        if (m_intersectionAdherents == null) {
+            return;
+        }
+
+        for (int i=0; i < m_intersectionAdherents.Count; ++i) {
+            WeakReference obj = m_intersectionAdherents[i];
+            if (obj.IsAlive && adherent == (Adherent)obj.Target) {
+                m_intersectionAdherents.Remove(obj);
+                break;
+            }
+        }
+
+        if (m_intersectionAdherents.Count == 0) {
+            Respawn(fount);
+        }
     }
 
     public bool canCollide {

--- a/Automata/Assets/Scripts/UI/UICircle.cs
+++ b/Automata/Assets/Scripts/UI/UICircle.cs
@@ -3,7 +3,7 @@ using System.Collections;
 
 public class UICircle : UIObject {
     public override void toAdherent(Adherent target, Vector2[] points) {
-        target.setpath(toPath(points));
+        target.setPath(toPath(points));
         target.setType((int)Adherent.adTypes.Circle);
     }
 

--- a/Automata/Assets/Scripts/UI/UIDiamond.cs
+++ b/Automata/Assets/Scripts/UI/UIDiamond.cs
@@ -3,7 +3,7 @@ using System.Collections;
 
 public class UIDiamond : UIObject {
     public override void toAdherent(Adherent target, Vector2[] points) {
-        target.setpath(toPath(points));
+        target.setPath(toPath(points));
         target.setType((int)Adherent.adTypes.Diamond);
     }
 

--- a/Automata/Assets/Scripts/UI/UIRectangle.cs
+++ b/Automata/Assets/Scripts/UI/UIRectangle.cs
@@ -4,7 +4,7 @@ using System.Collections;
 public class UIRectangle : UIObject {
 
     public override void toAdherent(Adherent target, Vector2[] points) {
-        target.setpath(toPath(points));
+        target.setPath(toPath(points));
         target.setType((int)Adherent.adTypes.Rectangle);
     }
 

--- a/Automata/Assets/Scripts/UI/UITriangle.cs
+++ b/Automata/Assets/Scripts/UI/UITriangle.cs
@@ -3,7 +3,7 @@ using System.Collections;
 
 public class UITriangle : UIObject {
     public override void toAdherent(Adherent target, Vector2[] points) {
-        target.setpath(toPath(points));
+        target.setPath(toPath(points));
         target.setType((int)Adherent.adTypes.Triangle);
     }
 

--- a/Automata/Assets/Scripts/World.cs
+++ b/Automata/Assets/Scripts/World.cs
@@ -150,10 +150,15 @@ public class World : MonoBehaviour {
             return;
         }
 
+        int adLevel = adherent.level;
+        Resource levelRes = ResourceManager.levelResource(adLevel);
+        Fountain levelFount = lData[adLevel].Fountain;
+
         if (adherent.isCarrying) {
-            int adLevel = adherent.level;
-            Resource levelRes = ResourceManager.levelResource(adLevel);
-            levelRes.Respawn(lData[adLevel].Fountain);
+            levelRes.Respawn(levelFount);
+        }
+        else if (!levelRes.hasParent()) {
+            levelRes.notifyOfAdherentRemove(adherent, levelFount);
         }
 
         adherentObjects.Remove(adherent);


### PR DESCRIPTION
Fixes #54 

Now, if a relic is sitting at the intersection of two paths and those two paths are removed before the relic is picked up, the relic will reset to the start of the level.
