### PR TITLE
Reduce collider sizes for both the resource and the adherent.

### DIFF
--- a/Automata/Assets/Objects/Prefabs/Adherent.prefab
+++ b/Automata/Assets/Objects/Prefabs/Adherent.prefab
@@ -183,7 +183,7 @@ CircleCollider2D:
   m_UsedByEffector: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 25
+  m_Radius: 10
 --- !u!96 &9657276
 TrailRenderer:
   m_ObjectHideFlags: 1
@@ -327,7 +327,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 0}
       propertyPath: m_Radius
-      value: 0.8
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 0}
       propertyPath: m_LocalPosition.z

--- a/Automata/Assets/Objects/Prefabs/Resource.prefab
+++ b/Automata/Assets/Objects/Prefabs/Resource.prefab
@@ -72,7 +72,7 @@ CircleCollider2D:
   m_UsedByEffector: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.6
+  m_Radius: 0.25
 --- !u!114 &11469236
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -84,6 +84,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 830b1473f70014e7e84779d2a8f11bce, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  parent: {fileID: 0}
+  level: 0
 --- !u!212 &21231706
 SpriteRenderer:
   m_ObjectHideFlags: 1
@@ -165,7 +167,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 0}
       propertyPath: m_Radius
-      value: 0.35
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 0}
       propertyPath: m_IsTrigger


### PR DESCRIPTION
This cuts down on errant pick-ups without jeopardizing playability.

@indieus: This is something that can be tweaked from Unity without requiring any programming. Perhaps you'd like to take a look yourself? I played through a few levels with these collider sizes and it seemed like an improvement. For instance, the intersection required for the second level used to be difficult. It seems to work much better now. 
